### PR TITLE
#1 - Generalize error backtrace

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -1,2 +1,1 @@
-use crate::parsing::{Expr, Statement, Multiplier, ComparisonOperator};
-
+use crate::parsing::{ComparisonOperator, Expr, Multiplier, Statement};

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,10 @@ use crate::parsing::*;
 use pest::{
     error::{Error, ErrorVariant, LineColLocation},
     iterators::{Pair, Pairs},
+    Span,
 };
+
+use std::fmt::Debug;
 
 #[derive(Debug)]
 pub enum Stage {
@@ -16,37 +19,38 @@ pub enum Stage {
 
 #[derive(Debug, Default)]
 pub struct Trace {
-    stack: Vec<(Stage, Error<Rule>)>,
+    stack: Vec<(Stage, Box<dyn TraceError>)>,
 }
 
-impl From<(Stage, Error<Rule>)> for Trace {
-    fn from((stage, err): (Stage, Error<Rule>)) -> Self {
+trait TraceError: Debug {
+    fn from_span(span: Span, message: &str) -> Self
+    where
+        Self: Sized;
+    fn line_col(&self) -> LineColLocation;
+    fn line(&self) -> &str;
+    fn message(&self) -> &str;
+}
+
+impl<T: TraceError + 'static> From<(Stage, T)> for Trace {
+    fn from((stage, err): (Stage, T)) -> Self {
         Trace {
-            stack: vec![(stage, err)],
+            stack: vec![(stage, Box::new(err))],
         }
     }
 }
 
-impl From<Error<Rule>> for Trace {
-    fn from(err: Error<Rule>) -> Self {
+impl<T: TraceError + 'static> From<T> for Trace {
+    fn from(err: T) -> Self {
         Trace {
-            stack: vec![(Stage::Parsing, err)],
-        }
-    }
-}
-
-impl From<Box<Error<Rule>>> for Trace {
-    fn from(err: Box<Error<Rule>>) -> Self {
-        Trace {
-            stack: vec![(Stage::Parsing, *err)],
+            stack: vec![(Stage::Parsing, Box::new(err))],
         }
     }
 }
 
 impl Trace {
-    pub fn new(stage: Stage, err: Error<Rule>) -> Self {
+    pub fn new<T: TraceError + 'static>(stage: Stage, err: T) -> Self {
         Trace {
-            stack: vec![(stage, err)],
+            stack: vec![(stage, Box::new(err))],
         }
     }
 
@@ -55,18 +59,58 @@ impl Trace {
         res.push_message(stage, pair, message);
         res
     }
-}
 
-impl Trace {
-    pub fn push(&mut self, stage: Stage, err: Error<Rule>) {
-        self.stack.push((stage, err))
+    pub fn push<T: TraceError + 'static>(&mut self, stage: Stage, err: T) {
+        self.stack.push((stage, Box::new(err)))
     }
 
     pub fn push_message(&mut self, stage: Stage, pair: &Pair<Rule>, message: String) {
         self.stack.push((
             stage,
-            Error::new_from_span(ErrorVariant::CustomError { message }, pair.as_span()),
+            Box::new(PestError::from_span(pair.as_span(), message.as_ref())),
         ))
+    }
+}
+
+#[derive(Debug)]
+struct PestError {
+    line_col: LineColLocation,
+    line: String,
+    message: String,
+}
+
+impl TraceError for PestError {
+    fn from_span(span: Span, message: &str) -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            line_col: LineColLocation::Span(span.start_pos().line_col(), span.end_pos().line_col()),
+            line: span.as_str().to_owned(),
+            message: message.to_owned(),
+        }
+    }
+
+    fn line_col(&self) -> LineColLocation {
+        self.line_col
+    }
+
+    fn line(&self) -> &str {
+        self.line.as_ref()
+    }
+
+    fn message(&self) -> &str {
+        self.message.as_ref()
+    }
+}
+
+impl From<Error<Rule>> for PestError {
+    fn from(err: Error<Rule>) -> Self {
+        Self {
+            line_col: err.line_col,
+            line: err.line().to_owned(),
+            message: err.variant.message().to_string(),
+        }
     }
 }
 
@@ -78,7 +122,7 @@ impl std::fmt::Display for Trace {
             self.stack
                 .iter()
                 .map(|(stage, err)| {
-                    let line_nbr = match err.line_col {
+                    let line_nbr = match err.line_col() {
                         LineColLocation::Pos((y, _)) => y,
                         LineColLocation::Span((ys, _), _) => ys,
                     };
@@ -90,7 +134,7 @@ impl std::fmt::Display for Trace {
                     let arrow = format!("{}>", "-".repeat(line_nbr_len));
 
                     // Error coordinates
-                    let coords = match err.line_col {
+                    let coords = match err.line_col() {
                         LineColLocation::Pos((y, x)) => format!("{y}:{x}"),
                         LineColLocation::Span((ys, xs), (ye, xe)) => {
                             format!("{ys}:{xs} -> {ye}:{xe}")
@@ -98,7 +142,7 @@ impl std::fmt::Display for Trace {
                     };
 
                     // Underline
-                    let underline = match err.line_col {
+                    let underline = match err.line_col() {
                         LineColLocation::Pos((_, x)) => format!("{}^", " ".repeat(x)),
                         LineColLocation::Span((ys, xs), (ye, xe)) => {
                             if ys == ye {
@@ -123,7 +167,7 @@ impl std::fmt::Display for Trace {
                         // Line number and line
                         format_args!("{}| {}", line_nbr, err.line()),
                         // Error
-                        err.variant.message()
+                        err.message()
                     )
                 })
                 .collect::<String>(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ pub struct Trace {
     stack: Vec<(Stage, Box<dyn TraceError>)>,
 }
 
-trait TraceError: Debug {
+pub trait TraceError: Debug {
     fn from_span(span: Span, message: &str) -> Self
     where
         Self: Sized;
@@ -73,7 +73,7 @@ impl Trace {
 }
 
 #[derive(Debug)]
-struct PestError {
+pub struct PestError {
     line_col: LineColLocation,
     line: String,
     message: String,
@@ -92,7 +92,7 @@ impl TraceError for PestError {
     }
 
     fn line_col(&self) -> LineColLocation {
-        self.line_col
+        self.line_col.clone()
     }
 
     fn line(&self) -> &str {
@@ -107,7 +107,7 @@ impl TraceError for PestError {
 impl From<Error<Rule>> for PestError {
     fn from(err: Error<Rule>) -> Self {
         Self {
-            line_col: err.line_col,
+            line_col: err.line_col.clone(),
             line: err.line().to_owned(),
             message: err.variant.message().to_string(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 #![allow(unused)]
 
+mod binding;
 mod error;
 mod parsing;
-mod binding;
 
 extern crate pest;
 #[macro_use]


### PR DESCRIPTION
Resolves #1 

**What it does:**
 - Makes use of new TraceError trait to generalize the stack trace