### PR TITLE
#3-AddSpanToASTNodes

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,0 +1,3 @@
+pub mod pest_error;
+pub mod span;
+pub mod trace;

--- a/src/error/pest_error.rs
+++ b/src/error/pest_error.rs
@@ -1,0 +1,47 @@
+use super::{span::Span, trace::TraceError};
+
+use crate::parsing::Rule;
+
+use pest::error::{Error, LineColLocation};
+
+#[derive(Debug)]
+pub struct PestError {
+    line_col: LineColLocation,
+    line: String,
+    message: String,
+}
+
+impl TraceError for PestError {
+    fn from_span(span: Span, message: &str) -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            line_col: span.line_col().clone(),
+            line: span.as_str().to_owned(),
+            message: message.to_owned(),
+        }
+    }
+
+    fn line_col(&self) -> LineColLocation {
+        self.line_col.clone()
+    }
+
+    fn line(&self) -> &str {
+        self.line.as_ref()
+    }
+
+    fn message(&self) -> &str {
+        self.message.as_ref()
+    }
+}
+
+impl From<Error<Rule>> for PestError {
+    fn from(err: Error<Rule>) -> Self {
+        Self {
+            line_col: err.line_col.clone(),
+            line: err.line().to_owned(),
+            message: err.variant.message().to_string(),
+        }
+    }
+}

--- a/src/error/span.rs
+++ b/src/error/span.rs
@@ -1,6 +1,6 @@
 use pest::error::LineColLocation;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Span {
     line: String,
     location: LineColLocation,

--- a/src/error/span.rs
+++ b/src/error/span.rs
@@ -1,6 +1,6 @@
 use pest::error::LineColLocation;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Span {
     line: String,
     location: LineColLocation,

--- a/src/error/span.rs
+++ b/src/error/span.rs
@@ -1,0 +1,26 @@
+use pest::error::LineColLocation;
+
+#[derive(Clone, Debug)]
+pub struct Span {
+    line: String,
+    location: LineColLocation,
+}
+
+impl Span {
+    pub fn as_str(&self) -> &str {
+        self.line.as_ref()
+    }
+
+    pub fn line_col(&self) -> &LineColLocation {
+        &self.location
+    }
+}
+
+impl From<pest::Span<'_>> for Span {
+    fn from(span: pest::Span) -> Self {
+        Self {
+            line: span.as_str().to_string(),
+            location: LineColLocation::Span(span.start_pos().line_col(), span.end_pos().line_col()),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ mod test {
 
     fn run_tests<F>(path: &str, check: F)
     where
-        F: Fn(Result<Vec<Statement>, Trace>) -> bool,
+        F: Fn(Result<Vec<AyNode<Statement>>, Trace>) -> bool,
     {
         let folder = format!("{TEST_FOLDER}/{path}");
         let mut entries = std::fs::read_dir(folder.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 
-use crate::{error::*, parsing::*};
+use crate::{error::trace::Trace, parsing::*};
 
 use pest::{
     error::{Error, ErrorVariant},

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,5 +1,6 @@
 use crate::error::{
     pest_error::PestError,
+    span::Span,
     trace::{Stage, Trace},
 };
 
@@ -9,7 +10,7 @@ use {
     pest::{
         error::{Error, ErrorVariant},
         iterators::{Pair, Pairs},
-        Parser, Span,
+        Parser,
     },
     strum_macros::EnumString,
 };
@@ -25,57 +26,58 @@ pub enum SourceCode {
 pub struct AyParser;
 
 /// Node containing a `Span` of code and the corresponding AST
-pub struct AyNode<'span, Inner: Node> {
-    span: Span<'span>,
+#[derive(Clone, Debug, PartialEq)]
+pub struct AyNode<Inner: Node> {
+    span: Span,
     inner: Inner,
 }
 
 pub trait Node {}
 
 /// A statement is anything that cannot be expected to return a value.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Statement {
     FunDec {
         name: String,
         args: Vec<String>,
-        body: Vec<Statement>,
+        body: Vec<AyNode<Statement>>,
     },
     VarDec {
         names: Vec<String>,
-        values: Vec<Expr>,
+        values: Vec<AyNode<Expr>>,
     },
-    Expr(Expr),
+    Expr(AyNode<Expr>),
     If {
-        cond: Expr,
-        then: Vec<Statement>,
-        otherwise: Vec<Statement>,
+        cond: AyNode<Expr>,
+        then: Vec<AyNode<Statement>>,
+        otherwise: Vec<AyNode<Statement>>,
     },
     Loop {
-        cond: Option<Expr>,
-        body: Vec<Statement>,
+        cond: Option<AyNode<Expr>>,
+        body: Vec<AyNode<Statement>>,
     },
 }
 impl Node for Statement {}
 
 /// An expression is anything that is or returns a value.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Expr {
     FunCall {
         name: String,
-        args: Vec<Expr>,
+        args: Vec<AyNode<Expr>>,
     },
     Array {
-        items: Vec<Expr>,
+        items: Vec<AyNode<Expr>>,
     },
     Comparison {
-        left: Box<Expr>,
-        right: Box<Expr>,
+        left: Box<AyNode<Expr>>,
+        right: Box<AyNode<Expr>>,
         operator: ComparisonOperator,
     },
     Number(i64),
     String(String),
     Ident(String),
-    Negated(Box<Expr>),
+    Negated(Box<AyNode<Expr>>),
 }
 impl Node for Expr {}
 
@@ -95,9 +97,9 @@ pub enum ComparisonOperator {
 }
 
 /// Pushes new error onto stacktrace or returns pred(pair).
-fn handle<F, T>(parent: &Pair<Rule>, pair: Pair<Rule>, pred: &F) -> Result<T, Trace>
+fn handle<F, T: Node>(parent: &Pair<Rule>, pair: Pair<Rule>, pred: &F) -> Result<AyNode<T>, Trace>
 where
-    F: Fn(Pair<Rule>) -> Result<T, Trace>,
+    F: Fn(Pair<Rule>) -> Result<AyNode<T>, Trace>,
 {
     let (span, rule) = (parent.as_span(), parent.as_rule());
     pred(pair).map_err(|mut trace| {
@@ -116,12 +118,16 @@ where
     })
 }
 
-fn handle_iter<F, T>(parent: &Pair<Rule>, iter: &mut Pairs<Rule>, pred: &F) -> Result<Vec<T>, Trace>
+fn handle_iter<F, T: Node>(
+    parent: &Pair<Rule>,
+    iter: &mut Pairs<Rule>,
+    pred: &F,
+) -> Result<Vec<AyNode<T>>, Trace>
 where
-    F: Fn(Pair<Rule>) -> Result<T, Trace>,
+    F: Fn(Pair<Rule>) -> Result<AyNode<T>, Trace>,
 {
     iter.map(|item| handle(parent, item, pred))
-        .collect::<Result<Vec<T>, Trace>>()
+        .collect::<Result<Vec<AyNode<T>>, Trace>>()
 }
 
 macro_rules! fields {
@@ -147,30 +153,42 @@ macro_rules! fields {
     };
 }
 
-fn build_ast_from_expr(pair: Pair<Rule>) -> Result<Expr, Trace> {
+fn build_ast_from_expr(pair: Pair<Rule>) -> Result<AyNode<Expr>, Trace> {
     match pair.as_rule() {
         Rule::expr => build_ast_from_expr(pair.into_inner().next().unwrap()),
-        Rule::negation => Ok(Expr::Negated(Box::new(handle(
-            &pair.clone(),
-            pair.into_inner().next().unwrap(),
-            &build_ast_from_expr,
-        )?))),
+        Rule::negation => Ok(AyNode {
+            span: pair.as_span().into(),
+            inner: Expr::Negated(Box::new(handle(
+                &pair.clone(),
+                pair.into_inner().next().unwrap(),
+                &build_ast_from_expr,
+            )?)),
+        }),
         Rule::fun_call => {
+            let span = pair.as_span();
             fields!(pair |> children: name);
 
             let name = name.as_span().as_str().to_owned();
             let args = handle_iter(&pair, &mut children, &build_ast_from_expr)?;
 
-            Ok(Expr::FunCall { name, args })
+            Ok(AyNode {
+                span: span.into(),
+                inner: Expr::FunCall { name, args },
+            })
         }
         Rule::array => {
+            let span = pair.as_span();
             fields!(pair |> children: items);
 
             let items = handle_iter(&pair, &mut items.into_inner(), &build_ast_from_expr)?;
 
-            Ok(Expr::Array { items })
+            Ok(AyNode {
+                span: span.into(),
+                inner: Expr::Array { items },
+            })
         }
         Rule::comparison => {
+            let span = pair.as_span();
             fields!(pair |> children: left, right, comparison);
 
             let left = handle(&pair, left, &build_ast_from_expr)?;
@@ -182,10 +200,13 @@ fn build_ast_from_expr(pair: Pair<Rule>) -> Result<Expr, Trace> {
                 )
             })?;
 
-            Ok(Expr::Comparison {
-                left: Box::new(left),
-                right: Box::new(right),
-                operator,
+            Ok(AyNode {
+                span: span.into(),
+                inner: Expr::Comparison {
+                    left: Box::new(left),
+                    right: Box::new(right),
+                    operator,
+                },
             })
         }
         Rule::number => {
@@ -225,10 +246,19 @@ fn build_ast_from_expr(pair: Pair<Rule>) -> Result<Expr, Trace> {
                 )
             })? * mult;
 
-            Ok(Expr::Number(result))
+            Ok(AyNode {
+                span: span.into(),
+                inner: Expr::Number(result),
+            })
         }
-        Rule::string => Ok(Expr::String(pair.as_span().as_str().to_owned())),
-        Rule::ident | Rule::fun_ident => Ok(Expr::Ident(pair.as_span().as_str().to_owned())),
+        Rule::string => Ok(AyNode {
+            span: pair.as_span().into(),
+            inner: Expr::String(pair.as_span().as_str().to_owned()),
+        }),
+        Rule::ident | Rule::fun_ident => Ok(AyNode {
+            span: pair.as_span().into(),
+            inner: Expr::Ident(pair.as_span().as_str().to_owned()),
+        }),
         rule => Err(Trace::new::<PestError>(
             Stage::AstBuilding,
             Error::new_from_span(
@@ -242,13 +272,12 @@ fn build_ast_from_expr(pair: Pair<Rule>) -> Result<Expr, Trace> {
     }
 }
 
-fn build_ast_from_statement(pair: Pair<Rule>) -> Result<Statement, Trace> {
+fn build_ast_from_statement(pair: Pair<Rule>) -> Result<AyNode<Statement>, Trace> {
     match pair.as_rule() {
-        Rule::expr => Ok(Statement::Expr(handle(
-            &pair.clone(),
-            pair,
-            &build_ast_from_expr,
-        )?)),
+        Rule::expr => Ok(AyNode {
+            span: pair.as_span().into(),
+            inner: Statement::Expr(handle(&pair.clone(), pair, &build_ast_from_expr)?),
+        }),
         Rule::fun_dec => {
             let span = pair.as_span();
 
@@ -266,7 +295,10 @@ fn build_ast_from_statement(pair: Pair<Rule>) -> Result<Statement, Trace> {
                 handle_iter(&pair, &mut body.into_inner(), &build_ast_from_statement)
             })?;
 
-            Ok(Statement::FunDec { name, args, body })
+            Ok(AyNode {
+                span: span.into(),
+                inner: Statement::FunDec { name, args, body },
+            })
         }
         Rule::var_dec => {
             let span = pair.as_span();
@@ -296,19 +328,23 @@ fn build_ast_from_statement(pair: Pair<Rule>) -> Result<Statement, Trace> {
                 ));
             }
 
-            Ok(Statement::VarDec {
-                names: idents
-                    .iter()
-                    .map(|ident| ident.as_span().as_str().to_owned())
-                    .collect(),
+            Ok(AyNode {
+                span: span.into(),
+                inner: Statement::VarDec {
+                    names: idents
+                        .iter()
+                        .map(|ident| ident.as_span().as_str().to_owned())
+                        .collect(),
 
-                values: values
-                    .iter()
-                    .map(|value| build_ast_from_expr(value.clone()))
-                    .collect::<Result<Vec<Expr>, Trace>>()?,
+                    values: values
+                        .iter()
+                        .map(|value| build_ast_from_expr(value.clone()))
+                        .collect::<Result<Vec<AyNode<Expr>>, Trace>>()?,
+                },
             })
         }
         Rule::if_block => {
+            let span = pair.as_span();
             fields!(pair |> children: cond, then);
 
             let cond = build_ast_from_expr(cond)?;
@@ -323,20 +359,27 @@ fn build_ast_from_statement(pair: Pair<Rule>) -> Result<Statement, Trace> {
                     &build_ast_from_statement,
                 )?;
 
-                Ok(Statement::If {
-                    cond,
-                    then,
-                    otherwise,
+                Ok(AyNode {
+                    span: span.into(),
+                    inner: Statement::If {
+                        cond,
+                        then,
+                        otherwise,
+                    },
                 })
             } else {
-                Ok(Statement::If {
-                    cond,
-                    then,
-                    otherwise: vec![],
+                Ok(AyNode {
+                    span: pair.as_span().into(),
+                    inner: Statement::If {
+                        cond,
+                        then,
+                        otherwise: vec![],
+                    },
                 })
             }
         }
         Rule::loop_block => {
+            let span = pair.as_span();
             fields!(pair |> children);
 
             let mut child = children.next().unwrap();
@@ -357,7 +400,10 @@ fn build_ast_from_statement(pair: Pair<Rule>) -> Result<Statement, Trace> {
                 )
             };
 
-            Ok(Statement::Loop { cond, body })
+            Ok(AyNode {
+                span: span.into(),
+                inner: Statement::Loop { cond, body },
+            })
         }
         Rule::statement => Ok(build_ast_from_statement(pair.into_inner().next().unwrap())?),
         rule => Err(Trace::new::<PestError>(
@@ -373,8 +419,8 @@ fn build_ast_from_statement(pair: Pair<Rule>) -> Result<Statement, Trace> {
     }
 }
 
-pub fn parse(source: SourceCode) -> Result<Vec<Statement>, Trace> {
-    let mut ast: Vec<Statement> = vec![];
+pub fn parse(source: SourceCode) -> Result<Vec<AyNode<Statement>>, Trace> {
+    let mut ast: Vec<AyNode<Statement>> = vec![];
 
     let (mut path, content) = match source {
         SourceCode::File(path) => {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,4 +1,7 @@
-use crate::error::*;
+use crate::error::{
+    pest_error::PestError,
+    trace::{Stage, Trace},
+};
 
 use std::{path::Path, str::FromStr};
 
@@ -173,8 +176,7 @@ fn build_ast_from_expr(pair: Pair<Rule>) -> Result<Expr, Trace> {
             let left = handle(&pair, left, &build_ast_from_expr)?;
             let right = handle(&pair, right, &build_ast_from_expr)?;
             let operator = ComparisonOperator::from_str(comparison.as_str()).map_err(|_| {
-                Trace::new_from_message(
-                    Stage::Parsing,
+                Trace::new_from_pair(
                     &pair,
                     format!("Unimplemented comparison operator: `{comparison}`"),
                 )

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -26,7 +26,7 @@ pub enum SourceCode {
 pub struct AyParser;
 
 /// Node containing a `Span` of code and the corresponding AST
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AyNode<Inner: Node> {
     span: Span,
     inner: Inner,

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -6,7 +6,7 @@ use {
     pest::{
         error::{Error, ErrorVariant},
         iterators::{Pair, Pairs},
-        Parser,
+        Parser, Span,
     },
     strum_macros::EnumString,
 };
@@ -20,6 +20,11 @@ pub enum SourceCode {
 #[derive(Parser)]
 #[grammar = "../pest/grammar.pest"]
 pub struct AyParser;
+
+pub enum AyNode<'s> {
+    Statement(Span<'s>, Statement),
+    Expr(Span<'s>, Expr),
+}
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Statement {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -21,11 +21,15 @@ pub enum SourceCode {
 #[grammar = "../pest/grammar.pest"]
 pub struct AyParser;
 
-pub enum AyNode<'s> {
-    Statement(Span<'s>, Statement),
-    Expr(Span<'s>, Expr),
+/// Node containing a `Span` of code and the corresponding AST
+pub struct AyNode<'span, Inner: Node> {
+    span: Span<'span>,
+    inner: Inner,
 }
 
+pub trait Node {}
+
+/// A statement is anything that cannot be expected to return a value.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Statement {
     FunDec {
@@ -48,7 +52,9 @@ pub enum Statement {
         body: Vec<Statement>,
     },
 }
+impl Node for Statement {}
 
+/// An expression is anything that is or returns a value.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Expr {
     FunCall {
@@ -68,6 +74,7 @@ pub enum Expr {
     Ident(String),
     Negated(Box<Expr>),
 }
+impl Node for Expr {}
 
 #[derive(Debug, EnumString)]
 #[repr(i64)]

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -446,18 +446,13 @@ pub fn parse(source: SourceCode) -> Result<Vec<Statement>, Trace> {
     Ok(ast)
 }
 
-pub fn recursive_print(cur: Option<&Pair<Rule>>, depth: u8) {
+pub fn recursive_print(cur: Option<&Pair<Rule>>, depth: usize) {
     if let Some(node) = cur {
         let rule = node.as_rule();
 
-        // TODO: simplify this using .repeat()
-        let indent = (0..depth)
-            .map(|_| "\x1b[32m|   \x1b[0m")
-            .collect::<String>();
-
         println!(
             "{}\x1b[1;33m{:?}\x1b[0m:'{}'",
-            indent,
+            format_args!("\x1b[31m{}\x1b[0m", "|   ".repeat(depth)),
             rule,
             node.as_span()
                 .as_str()


### PR DESCRIPTION
Resolves #3
Resolves #6

**What it does:**
 - Refactors errors into sub-module
 - Generalizes errors for easier modular architecture
 - Add Span information to nodes for clear error reporting
